### PR TITLE
fix: Gate destructive routes even when general API auth is unconfigured

### DIFF
--- a/src/auth/api_token.py
+++ b/src/auth/api_token.py
@@ -114,14 +114,20 @@ def init_api_token_auth(app) -> None:
     # effective configuration depend on the environment at call time.
     admin_tokens = _load_admin_tokens()
 
+    # Destructive operations are guarded even when general API authentication
+    # is off. Without this, a deployment that simply lacks API_TOKENS — as
+    # happened on the Render instance, where FLASK_ENV is not "production" —
+    # left POST /api/rag/reload and DELETE /api/rag/sources/<id> callable by
+    # anyone, which is precisely what ADMIN_TOKENS exists to prevent.
+    general_auth_off = _auth_disabled() or not tokens
+
     if _auth_disabled():
         logger.critical(
-            "API_AUTH_DISABLED is set: every business route is reachable "
-            "without a token. Never do this on an internet-facing instance."
+            "API_AUTH_DISABLED is set: business routes are reachable without a "
+            "token. Never do this on an internet-facing instance. Destructive "
+            "operations remain gated by ADMIN_TOKENS."
         )
-        return
-
-    if not tokens:
+    elif not tokens:
         if is_production:
             raise RuntimeError(
                 "API_TOKENS must be set when FLASK_ENV=production. Generate one "
@@ -131,9 +137,9 @@ def init_api_token_auth(app) -> None:
             )
         logger.warning(
             "API_TOKENS is not set — business routes are unauthenticated. "
-            "This is allowed outside production only."
+            "This is allowed outside production only. Destructive operations "
+            "remain gated by ADMIN_TOKENS."
         )
-        return
 
     @app.before_request
     def _require_api_token():  # pylint: disable=unused-variable
@@ -148,6 +154,7 @@ def init_api_token_auth(app) -> None:
         presented = _presented_token()
 
         if _is_admin_operation(request.method, request.path):
+            # Enforced regardless of general_auth_off.
             # Fails closed: with no ADMIN_TOKENS configured, destructive routes
             # are unreachable rather than falling back to the public token.
             if admin_tokens and presented and any(
@@ -155,6 +162,9 @@ def init_api_token_auth(app) -> None:
             ):
                 return None
             return jsonify({"error": "Unauthorized"}), 401
+
+        if general_auth_off:
+            return None
 
         if presented and any(hmac.compare_digest(presented, known) for known in tokens):
             return None

--- a/tests/backend/unit/test_api_token_auth.py
+++ b/tests/backend/unit/test_api_token_auth.py
@@ -242,3 +242,30 @@ class TestAdminFailsClosed(unittest.TestCase):
             "/api/rag/sources", headers={"Authorization": f"Bearer {TOKEN}"}
         )
         self.assertNotEqual(response.status_code, 401)
+
+
+class TestAdminGatedEvenWithoutGeneralAuth(unittest.TestCase):
+    """Destructive routes stay closed when general API auth is not configured.
+
+    A deployment that merely lacks API_TOKENS — the state the Render instance
+    was found in, where FLASK_ENV is not "production" — must not end up with
+    POST /api/rag/reload and DELETE /api/rag/sources/<id> callable by anyone.
+    """
+
+    def test_no_tokens_at_all_still_blocks_admin(self):
+        client = _client({"API_TOKENS": "", "ADMIN_TOKENS": ""})
+        self.assertEqual(client.post("/api/rag/reload").status_code, 401)
+        self.assertEqual(client.delete("/api/rag/sources/doc-1").status_code, 401)
+
+    def test_explicit_opt_out_still_blocks_admin(self):
+        client = _client({"API_TOKENS": "", "API_AUTH_DISABLED": "true", "ADMIN_TOKENS": ""})
+        self.assertEqual(client.post("/api/rag/reload").status_code, 401)
+        # Business routes remain open, which is what the opt-out is for.
+        self.assertNotEqual(client.post("/ask", json={"answers": {}}).status_code, 401)
+
+    def test_admin_token_still_works_without_general_auth(self):
+        client = _client({"API_TOKENS": "", "ADMIN_TOKENS": ADMIN_TOKEN})
+        response = client.post(
+            "/api/rag/reload", headers={"Authorization": f"Bearer {ADMIN_TOKEN}"}
+        )
+        self.assertNotEqual(response.status_code, 401)


### PR DESCRIPTION
Probing the Render instance after the merge showed it running this code with authentication effectively off:

    POST /ask                200  (no token)
    POST /api/rag/reload     200  (no token)

FLASK_ENV is not "production" there, so init_api_token_auth took the "no tokens, not production" branch and returned before registering the hook at all — taking the ADMIN_TOKENS gate with it. That defeats the purpose of having a separate admin credential: a deployment that merely forgets API_TOKENS ends up with reload and delete callable by anyone.

The admin check now runs independently of the general one. Business routes stay open when API_TOKENS is absent or API_AUTH_DISABLED is set — that is what those switches are for — but POST /api/rag/ingest, POST /api/rag/reload and DELETE /api/rag/sources/<id> require ADMIN_TOKENS in every configuration, and fail closed when it is unset.

This is not a regression from the migration: those routes were equally open before any of this work. It is the gap between what ADMIN_TOKENS was supposed to guarantee and what it actually did.

Suite: unit+api 197, integration 148, security 156, e2e 17, all passing.